### PR TITLE
Add domain exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.3.0
+
+### Additions
+
+- Added support for domain-based robots.txt configuration using `CANONICAL_HOST` environment variable.
+- Added ability to use original robots.txt for canonical domain while blocking others.
+
+### Changes
+
+- Made `BLOCK_ROBOTS` and `CANONICAL_HOST` environment variables mutually exclusive.
+- Updated Rails integration to insert middleware when either `BLOCK_ROBOTS` or `CANONICAL_HOST` is set.
+- Updated README with new configuration options and examples.
+
 ##0.2.5
 
 ### Additions

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    norobots (0.2.5)
+    norobots (0.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -24,12 +24,40 @@ Or install it yourself as:
     $ gem install norobots
 
 ## Usage
-Set `BLOCK_ROBOTS` environment variable and you are good to go! Any value is fine, as long as is defined.
+The middleware can be configured using environment variables. You can use either `BLOCK_ROBOTS` or `CANONICAL_HOST`, but not both.
 
 If you use Rails the middleware is loaded automatically.
 
-When `BLOCK_ROBOTS` environment variable is not set, the original `robots.txt` file
-in the public folder will be served.
+### Configuration Options
+
+1. No environment variables set:
+   - The original `robots.txt` file from your public folder will be served
+
+2. Only `BLOCK_ROBOTS` set:
+   - All domains will be blocked (Disallow: /)
+
+3. Only `CANONICAL_HOST` set:
+   - The canonical domain will use the original `robots.txt` from your public folder
+   - All other domains will be blocked (Disallow: /)
+
+Example:
+```ruby
+# In your Rails application
+
+# Option 1: Block all robots
+ENV['BLOCK_ROBOTS'] = 'true'
+# Result: All domains will be blocked
+
+# Option 2: Allow only canonical domain to use original robots.txt
+ENV['CANONICAL_HOST'] = 'example.com'
+# Result:
+# - example.com/robots.txt -> Uses your original robots.txt
+# - staging.example.com/robots.txt -> Blocks crawling
+# - any-other-domain.com/robots.txt -> Blocks crawling
+
+# Option 3: No environment variables
+# Result: Your original robots.txt from public folder is served
+```
 
 
 ## Development

--- a/lib/norobots/middleware.rb
+++ b/lib/norobots/middleware.rb
@@ -7,10 +7,30 @@ module Norobots
     end
 
     def call(env)
-      if env["PATH_INFO"] == "/robots.txt" && !ENV["BLOCK_ROBOTS"].nil?
-        [200, {"Content-Type" => "text/plain"}, ["User-Agent: *\nDisallow: /"]]
+      if env["PATH_INFO"] == "/robots.txt"
+        [200, {"Content-Type" => "text/plain"}, [robots_txt_content(env)]]
       else
         @app.call(env)
+      end
+    end
+
+    private
+
+    def robots_txt_content(env)
+      if ENV["BLOCK_ROBOTS"].nil? && ENV["CANONICAL_HOST"].nil?
+        return @app.call(env)[2].first
+      end
+
+      if ENV["CANONICAL_HOST"]
+        request_host = env["HTTP_HOST"]
+        canonical_host = ENV["CANONICAL_HOST"]
+        if request_host == canonical_host
+          @app.call(env)[2].first
+        else
+          "User-Agent: *\nDisallow: /"
+        end
+      else
+        "User-Agent: *\nDisallow: /"
       end
     end
   end

--- a/lib/norobots/rails.rb
+++ b/lib/norobots/rails.rb
@@ -3,7 +3,9 @@
 module Norobots
   class Railtie < Rails::Railtie
     initializer "norobots.configure_rack_middleware" do |app|
-      app.middleware.insert_before Rack::Sendfile, Norobots::Middleware unless ENV["BLOCK_ROBOTS"].nil?
+      if ENV["BLOCK_ROBOTS"] || ENV["CANONICAL_HOST"]
+        app.middleware.insert_before Rack::Sendfile, Norobots::Middleware
+      end
     end
   end
 end

--- a/lib/norobots/version.rb
+++ b/lib/norobots/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Norobots
-  VERSION = "0.2.5"
+  VERSION = "0.3.0"
 end

--- a/spec/norobots/middleware_spec.rb
+++ b/spec/norobots/middleware_spec.rb
@@ -14,24 +14,60 @@ RSpec.describe Norobots::Middleware do
 
   subject { described_class.new(app).call(env_args)[2] }
 
-  context "when there is a BLOCK_ROBOTS env set" do
+  context "when no environment variables are set" do
+    before do
+      allow(ENV).to receive(:[]).with("BLOCK_ROBOTS").and_return(nil)
+      allow(ENV).to receive(:[]).with("CANONICAL_HOST").and_return(nil)
+    end
+
+    it "passes through to the app" do
+      expect(subject).to eq ["Original request"]
+      expect(app).to have_received :call
+    end
+  end
+
+  context "when only BLOCK_ROBOTS is set" do
     before do
       allow(ENV).to receive(:[]).with("BLOCK_ROBOTS").and_return(true)
+      allow(ENV).to receive(:[]).with("CANONICAL_HOST").and_return(nil)
     end
 
     it "shows the default robots.txt content" do
       expect(subject).to eq ["User-Agent: *\nDisallow: /"]
       expect(app).not_to have_received :call
     end
+  end
 
-    context "when the request is not for robots.txt" do
-      let(:path_info) { "give_me_resources" }
+  context "when only CANONICAL_HOST is set" do
+    let(:canonical_host) { "example.com" }
 
-      it("does not do anything") { expect(subject).to eq ["Original request"] }
+    before do
+      allow(ENV).to receive(:[]).with("BLOCK_ROBOTS").and_return(nil)
+      allow(ENV).to receive(:[]).with("CANONICAL_HOST").and_return(canonical_host)
+    end
+
+    context "when request is from canonical host" do
+      let(:env_args) { default_env_args.merge("HTTP_HOST" => canonical_host) }
+
+      it "uses the original robots.txt" do
+        expect(subject).to eq ["Original request"]
+        expect(app).to have_received :call
+      end
+    end
+
+    context "when request is from non-canonical host" do
+      let(:env_args) { default_env_args.merge("HTTP_HOST" => "staging.example.com") }
+
+      it "disallows crawling" do
+        expect(subject).to eq ["User-Agent: *\nDisallow: /"]
+        expect(app).not_to have_received :call
+      end
     end
   end
 
-  context "when there is no BLOCK_ROBOTS env set" do
+  context "when the request is not for robots.txt" do
+    let(:path_info) { "give_me_resources" }
+
     it("does not do anything") { expect(subject).to eq ["Original request"] }
   end
 end


### PR DESCRIPTION
This PR introduces support for defining a canonical host within the application. It ensures that all non-canonical domains are blocked from indexing by search engine robots, helping to prevent duplicate content issues.

Review after #8 